### PR TITLE
feat: added method 'insert_multi'

### DIFF
--- a/couchbase_helper/__init__.py
+++ b/couchbase_helper/__init__.py
@@ -2,4 +2,4 @@ from .couch import CouchbaseHelper
 
 __all__ = ["CouchbaseHelper"]
 __author__ = "Thomas 'sitzz' Vang <sitzzdk@gmail.com>"
-__version__ = "0.0.5b"
+__version__ = "0.0.6b"

--- a/couchbase_helper/couch.py
+++ b/couchbase_helper/couch.py
@@ -121,7 +121,7 @@ class CouchbaseHelper:
 
         if per_key_opts is not None:
             for key, val in per_key_opts.items():
-                per_key_opts[key] = self._build_opts("upsert", opts=val)
+                per_key_opts[key] = self._build_opts("insert", opts=val)
 
             opts["per_key_options"] = per_key_opts
 
@@ -143,7 +143,7 @@ class CouchbaseHelper:
                     self.logger.error("unable to add document %s: %s", key, exception)
             else:
                 self.logger.info(
-                    "### DRYRUN: would upsert keys %s ###",
+                    "### DRYRUN: would insert keys %s ###",
                     ", ".join(list(documents.keys())),
                 )
                 self._save_dryrun_outputs(**args)

--- a/couchbase_helper/couch.py
+++ b/couchbase_helper/couch.py
@@ -114,7 +114,7 @@ class CouchbaseHelper:
             return False
 
     def insert_multi(
-            self, documents: dict, expiry=None, opts: dict = None, per_key_opts: dict = None
+        self, documents: dict, expiry=None, opts: dict = None, per_key_opts: dict = None
     ):
         if opts is None:
             opts = {}


### PR DESCRIPTION
- Added method `insert_multi` basically mimicking functionality of method `upsert_multi` as they're more or less the same.

Some error handling might be desirable, eg. if some keys aren't added due to key conflicts or similar.