### PR TITLE
Release branch for v0.0.13b

### DIFF
--- a/couchbase_helper/__init__.py
+++ b/couchbase_helper/__init__.py
@@ -5,4 +5,4 @@ from .timeout import Timeout
 
 __all__ = ["CouchbaseHelper", "Session", "Timeout", "BucketNotSet", "ScopeNotSet"]
 __author__ = "Thomas 'sitzz' Vang <sitzzdk@gmail.com>"
-__version__ = "0.0.12b"
+__version__ = "0.0.13b"

--- a/couchbase_helper/retry.py
+++ b/couchbase_helper/retry.py
@@ -1,0 +1,47 @@
+# Inspired by: https://docs.couchbase.com/python-sdk/current/howtos/error-handling.html
+from enum import Enum
+from functools import wraps
+from random import randint
+from time import sleep
+from typing import Callable, Optional, Tuple
+
+
+class RetryPolicy(Enum):
+    FLAT = 1
+    LINEAR = 2
+    EXPONENTIAL = 3
+    RANDOM = 4
+
+
+def retry(
+    attempts: int = 3,
+    delay: float = 0.1,
+    policy: RetryPolicy = RetryPolicy.FLAT,
+    exceptions: Optional[Tuple[Exception]] = None,
+) -> Callable:
+    def handler(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            for attempts_left in reversed(range(attempts)):
+                try:
+                    return func(*args, **kwargs)
+                except Exception as _exc:
+                    if exceptions is None or not isinstance(_exc, exceptions):
+                        raise
+
+                    if attempts_left == 0:
+                        raise
+
+                    backoff = delay
+                    if policy == RetryPolicy.LINEAR:
+                        backoff = delay * (attempts - attempts_left)
+                    if policy == RetryPolicy.EXPONENTIAL:
+                        backoff = (delay / 2) * (2 ** (attempts - attempts_left))
+                    if policy == RetryPolicy.RANDOM:
+                        backoff = delay * (randint(17, 233) / 100)
+
+                    sleep(backoff)
+
+        return wrapper
+
+    return handler


### PR DESCRIPTION
## Feat: retry mechanism (#22)
- Added decorator for methods: `couchbase_helper.retry.retry`
- Added retry policy enum: `couchbase_helper.retry.RetryPolicy`
- Decorator takes the following arguments:
  - `attempts` (`int`): The amount of tries that should be attempted.
  - `delay` (`float`): The amount of time between attempts. Also see 'policy' for details on how this is used.
  - `policy` (couchbase_helper.retry.RetryPolicy`): The policy to use for manipulating the delay. Options are:
    - `RetryPolicy.FLAT`: Use the same delay between attempts (1, 1, 1, 1...)
    - `RetryPolicy.LINEAR`: Multiply delay with the number of attempts between attempts (example: `1, 2, 3, 4...`)
    - `RetryPolicy.EXPONENTIAL`: Multiply delay to the second power between attempts (example: `1, 2, 4, 8...`)
    - `RetryPolicy.RANDOM`: Multiply delay with a random number between 0.17 and 2.33 (example: `0.56, 1.21, 0.87, 2.01...`)
  - `exceptions` (`Tuple[Exception]`): Which exceptions, if any, to allow retries for. It not set no retries are attempted (example: `(couchbase.exceptions.CasMismatchException)`).

