### PR TITLE
Feat/n1ql

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,11 @@ Couchbase Helper is currently rather basic and mostly/only support the following
 * `remove`
 * `remove_multi`
 
-It currently also has very basic functionality for view queries (`view_query`) and n1ql (`n1ql`) which aren't that
-fancy. There are ideas on how to enhance these, especially the `n1ql`  method, but still nothing specific. Follow issues
-[#9](https://github.com/sitzz/python-couchbase-helper/issues/9) and
+It currently also has very basic functionality for view queries (`view_query`) which isn't all that fancy. Follow issue
 [#18](https://github.com/sitzz/python-couchbase-helper/issues/18) for updates on this.
+
+An N1ql (SQL++) helper class is also available, which provides chainable methods to create SQL++ queries to select from
+indexes.
 
 # Installation
 
@@ -41,8 +42,9 @@ $ poetry add couchbase-helper
 ... and so on
 ```
 
-# Example
+# Examples
 
+**Basic operations**
 ```Python
 from couchbase_helper import CouchbaseHelper, Session
 
@@ -73,4 +75,29 @@ document["hello"] = "world"
 cb.upsert("foo1", document)
 ```
 
+**SQL++/N1QL examples**
+```Python
+from couchbase_helper import Session
+from couchbase_helper.n1ql import N1ql
 
+# Connect to Couchbase server/cluster
+session = Session(
+    hostname="localhost",
+    username="username",
+    password="password",
+    bucket="bucket",
+    timeout=10,
+)
+session.connect()
+n1ql = N1ql(session=session)
+
+# Select documents where foo=bar
+rows = n1ql.where("foo=", "bar").get()
+for row in rows:
+    ...
+
+# You can also select specific columns, from a different bucket , scope, or even collection than the session's:
+rows = n1ql.select("callsign").from_("travel-sample", "inventory", "airport").where("city=", "San Jose").or_where("city=", "New York").get()
+for row in rows:
+    ...
+```

--- a/README.md
+++ b/README.md
@@ -92,12 +92,12 @@ session.connect()
 n1ql = N1ql(session=session)
 
 # Select documents where foo=bar
-rows = n1ql.where("foo=", "bar").get()
+rows = n1ql.where("foo=", "bar").rows()
 for row in rows:
     ...
 
 # You can also select specific columns, from a different bucket , scope, or even collection than the session's:
-rows = n1ql.select("callsign").from_("travel-sample", "inventory", "airport").where("city=", "San Jose").or_where("city=", "New York").get()
+rows = n1ql.select("callsign").from_("travel-sample", "inventory", "airport").where("city=", "San Jose").or_where("city=", "New York").rows()
 for row in rows:
     ...
 ```

--- a/couchbase_helper/converters.py
+++ b/couchbase_helper/converters.py
@@ -1,0 +1,32 @@
+"""
+copied from https://github.com/PyMySQL/PyMySQL under MIT license
+
+Copyright (c) 2010, 2013 PyMySQL contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+"""
+
+_escape_table = [chr(x) for x in range(128)]
+_escape_table[0] = "\\0"
+_escape_table[ord("\\")] = "\\\\"
+_escape_table[ord("\n")] = "\\n"
+_escape_table[ord("\r")] = "\\r"
+_escape_table[ord("\032")] = "\\Z"
+_escape_table[ord('"')] = '\\"'
+_escape_table[ord("'")] = "\\'"
+
+
+def escape_string(value, mapping=None):
+    return value.translate(_escape_table)
+
+
+def escape_str(value, mapping=None):
+    return "'%s'" % escape_string(str(value), mapping)

--- a/couchbase_helper/helper.py
+++ b/couchbase_helper/helper.py
@@ -4,24 +4,16 @@ from typing import Any, Dict, List, Optional, Union
 
 from couchbase.diagnostics import ServiceType
 from couchbase.exceptions import DocumentExistsException, DocumentNotFoundException
-from couchbase.n1ql import N1QLQuery, QueryScanConsistency
 from couchbase.options import (
-    InsertMultiOptions,
     InsertOptions,
-    GetMultiOptions,
-    GetOptions,
-    QueryOptions,
-    RemoveMultiOptions,
-    RemoveOptions,
-    UpsertMultiOptions,
     UpsertOptions,
-    ViewOptions,
     WaitUntilReadyOptions,
 )
-from couchbase.result import QueryResult, GetResult, MultiGetResult
+from couchbase.result import GetResult, MultiGetResult
 
-from .protocols import SessionProt
 from ._types import JSONType
+from .options import build_opts
+from .protocols import SessionProt
 
 
 class CouchbaseHelper:
@@ -74,7 +66,7 @@ class CouchbaseHelper:
         args = {
             "key": key,
             "value": value,
-            "opts": self._build_opts("insert", opts=opts, expiry=expiry),
+            "opts": build_opts("insert", opts=opts, expiry=expiry),
         }
 
         try:
@@ -117,13 +109,13 @@ class CouchbaseHelper:
 
         if per_key_opts is not None:
             for key, val in per_key_opts.items():
-                per_key_opts[key] = self._build_opts("insert", opts=val)
+                per_key_opts[key] = build_opts("insert", opts=val)
 
             opts["per_key_options"] = per_key_opts
 
         args = {
             "keys_and_docs": documents,
-            "opts": self._build_opts("insert_multi", opts=opts, expiry=expiry),
+            "opts": build_opts("insert_multi", opts=opts, expiry=expiry),
         }
         try:
             self.session.cluster.wait_until_ready(
@@ -169,7 +161,7 @@ class CouchbaseHelper:
         args = {
             "key": key,
             "value": value,
-            "opts": self._build_opts("insert", opts=opts, expiry=expiry),
+            "opts": build_opts("insert", opts=opts, expiry=expiry),
         }
 
         try:
@@ -212,13 +204,13 @@ class CouchbaseHelper:
 
         if per_key_opts is not None:
             for key, val in per_key_opts.items():
-                per_key_opts[key] = self._build_opts("upsert", opts=val)
+                per_key_opts[key] = build_opts("upsert", opts=val)
 
             opts["per_key_options"] = per_key_opts
 
         args = {
             "keys_and_docs": documents,
-            "opts": self._build_opts("upsert_multi", opts=opts, expiry=expiry),
+            "opts": build_opts("upsert_multi", opts=opts, expiry=expiry),
         }
         try:
             self.session.cluster.wait_until_ready(
@@ -255,7 +247,7 @@ class CouchbaseHelper:
         Returns:
             :class:`couchbase.result.GetResult` | Dict[Any, Any] | None
         """
-        args = {"key": key, "opts": self._build_opts("get", opts=opts)}
+        args = {"key": key, "opts": build_opts("get", opts=opts)}
 
         try:
             self.session.cluster.wait_until_ready(
@@ -288,7 +280,7 @@ class CouchbaseHelper:
         Returns:
             :class:`couchbase.result.MultiGetResult` | List[Dict[Any, Any]] | None
         """
-        args = {"keys": keys, "opts": self._build_opts("get", opts=opts)}
+        args = {"keys": keys, "opts": build_opts("get", opts=opts)}
 
         try:
             ret = []
@@ -317,7 +309,7 @@ class CouchbaseHelper:
             (bool):
                 The status of the remove operation.
         """
-        args = {"key": key, "opts": self._build_opts("remove", opts=opts)}
+        args = {"key": key, "opts": build_opts("remove", opts=opts)}
 
         self.session.cluster.wait_until_ready(
             timedelta(self.session.timeout.kv),
@@ -346,7 +338,7 @@ class CouchbaseHelper:
             (bool):
                 The status of the remove operations.
         """
-        args = {"keys": keys, "opts": self._build_opts("remove", opts=opts)}
+        args = {"keys": keys, "opts": build_opts("remove", opts=opts)}
 
         self.session.cluster.wait_until_ready(
             timedelta(self.session.timeout.kv),
@@ -401,7 +393,7 @@ class CouchbaseHelper:
             query = self.session.bucket.view_query(
                 design_doc=design_doc,
                 view_name=view_name,
-                **self._build_opts("view", opts=opts),
+                **build_opts("view", opts=opts),
             )
             query_metadata = query.metadata()
             if query_metadata is not None:
@@ -416,127 +408,3 @@ class CouchbaseHelper:
             )
 
         return None
-
-    def n1ql(
-        self,
-        select: str = "*",
-        where: Optional[Dict[str, Any]] = None,
-        *,
-        opts: Optional[Dict[str, Any]] = None,
-    ) -> Optional[QueryResult]:
-        # TODO: method needs to be redone.
-        """
-        generate and execute an N1QL query
-        :param select: str
-        the columns to select, defaults to "*" (all)
-        :param where: Dict[str, Any]
-        A key-value dictionary for the select statement
-        :param opts: optional Dict[str, Any]
-        any custom options to use for the query operation
-        :return: List[Dict[Any, Any]] | None
-        """
-        if opts is None:
-            opts = {}
-
-        where_statement = ""
-        if where is not None:
-            for col, _ in where.items():
-                if len(where_statement) > 0:
-                    where_statement += " AND "
-                else:
-                    where_statement += " WHERE "
-                where_statement += f"{col}=${col}"
-
-        try:
-            self.session.cluster.wait_until_ready(
-                timedelta(self.session.timeout.kv),
-                WaitUntilReadyOptions(service_types=[ServiceType.Query]),
-            )
-            query = N1QLQuery(
-                f"SELECT {select} FROM `{self.session.bucket_name}`{where_statement}"
-            )
-            query.consistency = QueryScanConsistency.REQUEST_PLUS
-            query.timeout = self.session.timeout.query
-            return self.session.cluster.query(
-                query.statement, **self._build_opts("query", opts=opts), **where
-            ).rows()
-        except Exception as _err:
-            self.logger.error(
-                "an error occurred when performing N1QL query (%s): %s",
-                type(_err).__name__,
-                _err.args[0],
-            )
-
-        return None
-
-    def _build_opts(
-        self,
-        type_: str,
-        *,
-        opts: Optional[Dict[str, Any]] = None,
-        expiry: Optional[Union[int, timedelta]] = None,
-    ) -> Union[
-        InsertOptions,
-        InsertMultiOptions,
-        UpsertOptions,
-        UpsertMultiOptions,
-        GetOptions,
-        GetMultiOptions,
-        QueryOptions,
-        RemoveOptions,
-        RemoveMultiOptions,
-        ViewOptions,
-    ]:
-        """Generates operation options for specified operation type.
-
-        Args:
-            type_ (str):
-                The type of operation to return options for.
-            opts (Dict[str, Any]):
-                Initial options to use for initiating the operation options instance.
-            expiry (int | timedelta | None):
-                Any general document expiry to use for the operations.
-
-        Returns:
-            Dict[str, Any]
-        """
-        if opts is None:
-            opts = {}
-
-        default_timeout = timedelta(seconds=self.session.timeout.kv)
-        if type_ == "insert":
-            base_options = InsertOptions
-        elif type_ == "insert_multi":
-            base_options = InsertMultiOptions
-        elif type_ == "upsert":
-            base_options = UpsertOptions
-        elif type_ == "upsert_multi":
-            base_options = UpsertMultiOptions
-        elif type_ == "get":
-            base_options = GetOptions
-        elif type_ == "get_multi":
-            base_options = GetMultiOptions
-        elif type_ == "query":
-            base_options = QueryOptions
-            default_timeout = timedelta(seconds=self.session.timeout.query)
-        elif type_ == "remove":
-            base_options = RemoveOptions
-        elif type_ == "remove_multi":
-            base_options = RemoveMultiOptions
-        elif type_ == "view":
-            base_options = ViewOptions
-        else:
-            raise AttributeError(f"invalid attribute value {type_}")
-
-        if "timeout" not in opts:
-            opts["timeout"] = default_timeout
-
-        ret = base_options(**opts)
-
-        if ret is None:
-            ret = {}
-
-        if expiry is not None and isinstance(expiry, int):
-            ret["expiry"] = timedelta(seconds=expiry)
-
-        return ret

--- a/couchbase_helper/n1ql.py
+++ b/couchbase_helper/n1ql.py
@@ -5,7 +5,6 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from couchbase.n1ql import N1QLQuery, QueryScanConsistency
 from couchbase.options import QueryOptions
 
-from .converters import escape_str
 from .options import build_opts
 from .session import Session
 from .timeout import Timeout
@@ -297,8 +296,7 @@ class N1ql:
     @staticmethod
     def _clean_key(string):
         """clean a column/key from any non-word chars"""
-        new_key = re.sub(r"\W", "", string)
-        return escape_str(new_key)
+        return re.sub(r"\W", "", string)
 
     def _reset(self):
         """resets class variables and session"""

--- a/couchbase_helper/n1ql.py
+++ b/couchbase_helper/n1ql.py
@@ -1,0 +1,489 @@
+import logging
+import re
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+from couchbase.n1ql import N1QLQuery, QueryScanConsistency
+from couchbase.options import QueryOptions
+
+from .converters import escape_str
+from .options import build_opts
+from .session import Session
+from .timeout import Timeout
+
+_TIMEOUT = Timeout()
+
+
+class N1ql:
+    """A Couchbase SQL++ (N1QL) class making for easier and safer query building
+
+    Args:
+        session (implements :class:`~couchbase_helper.protocols.SessionProt`)
+            The cluster connection session
+        logger (:class:`logging.logger`):
+            The logging instance to use for log message. Defaults to the root logger.
+
+    Usage:
+        The class is intended used as chained methods, example:
+        ```
+        from couchbase_helper import Session
+        from couchbase_helper.n1ql import N1ql
+
+        session = Session("localhost", "user", "password", bucket="test")
+        n1ql = N1ql(session)
+
+        # select all restaurants from the "businesses" bucket
+        restaurants = n1ql.select("name").from_("businesses").where("type=", "restaurant").get()
+        for restaurant in restaurants:
+            ...
+
+        # select all butcher shops and bakeries from the "businesses" bucket
+        shops = n1ql.select("name").from_("businesses").where("type=", "butcher").or_where("type=", "bakery").get()
+        for shop in shops:
+            ...
+        ```
+    """
+
+    def __init__(self, session: Session, logger: Optional[logging.Logger] = None):
+        if logger is None:
+            logger = logging.getLogger()
+        self.logger = logger
+
+        self.session = session
+
+        if not self.session.connected:
+            self.session.connect()
+
+        # Query runtime variables
+        self._columns = ["*"]
+        self._distinct = False
+        self._conditions: List[Tuple[str, str, Any]] = []
+        self._reset: Dict[str, str] = {}
+
+    def select(self, columns: Optional[Union[str, List[str]]] = None):
+        """
+        Set the column or columns to select
+
+        Args:
+            columns (Union[str, List[str]]):
+                The column or columns to select in the query
+        Returns:
+            `self`
+        """
+        if columns is None:
+            columns = ["*"]
+        if isinstance(columns, str):
+            columns = [col.strip() for col in columns.split(",")]
+
+        self._columns = columns
+
+        return self
+
+    def distinct(self, enable: bool = True):
+        """
+        Will set query to select distinct values
+
+        Args:
+            enable (bool):
+                Whether the distinct flag should be enabled (True) or not (False).
+                This will always be reset to False when invoking the `get` method
+
+        Returns:
+            `self`
+        """
+        self._distinct = enable
+        return self
+
+    def from_(
+        self,
+        bucket: Optional[str] = None,
+        scope: Optional[str] = None,
+        collection: Optional[str] = None,
+    ):
+        if bucket is not None and bucket != self.session.bucket.name:
+            self._reset["bucket"] = self.session.bucket.name
+            self.session.bucket = bucket
+
+        if scope is not None and scope != self.session.scope.name:
+            self._reset["scope"] = self.session.scope.name
+            self.session.scope = scope
+
+        if collection is not None and collection != self.session.collection.name:
+            self._reset["collection"] = self.session.collection.name
+            self.session.collection = collection
+
+        return self
+
+    def where(self, key: str, value: Any):
+        """
+        Add an inclusive/and where condition
+
+        Args:
+            key (str):
+                The key (and optionally operator) to add to the condition expression.
+            value (Any):
+                The value to compare with.
+
+        Returns:
+             `self`
+        """
+        self._where("AND", key, value)
+
+        return self
+
+    def or_where(self, key: str, value: Any):
+        """
+        Add an exclusive/or where condition
+
+        Args:
+            key (str):
+                The key (and optionally operator) to add to the condition expression.
+            value (Any):
+                The value to compare with.
+
+        Returns:
+             `self`
+        """
+        self._where("OR", key, value)
+
+        return self
+
+    def orwhere(self, key: str, value: Any):
+        """an alias for :class:`or_where`"""
+        return self.or_where(key, value)
+
+    # TODO ... : def not_(self, ...):
+
+    def _where(self, type_: str, key: str, value: Any):
+        """adds and/or where conditions"""
+        cleaned_key = self._clean_key(key)
+        column = self._enclose_reserved_word(cleaned_key)
+        operator = None
+        if value is None and not self._has_operator(key):
+            operator = " IS NULL"
+        if not self._has_operator(key) or not operator:
+            operator = " ="
+
+        processed_key = f"{column}{operator}"
+
+        self._conditions.append((type_, processed_key, value))
+
+    def get(self, opts: Optional[QueryOptions] = None):
+        """
+
+        Args:
+             opts (optional `couchbase.options.QueryOptions`):
+                Any query options to use when executing the query.
+
+        Returns:
+            :class:`couchbase.result.QueryResult` iterable
+        """
+        # generate 'FROM' expression
+        from_ = self._enclose_reserved_word(self.session.bucket.name)
+        if (
+            self.session.scope.name != "_default"
+            or self.session.collection.name != "_default"
+        ):
+            from_ += f".{self._enclose_reserved_word(self.session.scope.name)}.{self._enclose_reserved_word(self.session.collection.name)}"
+
+        ident = from_[0:1]
+        prefix = f"{ident}."
+
+        # generate columns for selection
+        columns = ", ".join(
+            [
+                f"{prefix if col != '*' else ''}{self._enclose_reserved_word(col)}"
+                for col in self._columns
+            ]
+        )
+
+        # generate where expression
+        positional_arguments = []
+        where = ""
+        if self._conditions:
+            for idx, condition in enumerate(self._conditions, 1):
+                type_, key, value = condition
+                positional_arguments.append(value)
+                _where_part = f"{type_.upper() if len(where) else ''} {prefix}{key} ${idx}".strip()
+                where += f"{_where_part} "
+            where = f"WHERE {where}"
+
+        # init QueryOptions
+        if opts is None:
+            opts = {}
+        if positional_arguments:
+            opts["positional_parameters"] = positional_arguments
+        options = build_opts("query", opts=opts)
+
+        # generate the prepared statement
+        statement = f"SELECT{' DISTINCT' if self._distinct else ''} {columns} FROM {from_} {ident} {where}".strip()
+        try:
+            # initiate the N1QLQuery instance
+            query = N1QLQuery(statement)
+            query.consistency = QueryScanConsistency.REQUEST_PLUS
+            query.timeout = self.session.timeout.query
+
+            # select rows
+            rows = self.session.cluster.query(query.statement, **options).rows()
+
+            # reset class variables
+            if self._reset:
+                for prop, original in self._reset.items():
+                    setattr(self.session, prop, original)
+                self._reset = {}
+            self._distinct = False
+
+            # return
+            return rows
+        except (
+            Exception
+        ) as _err:  # intentionally broad initially to see what it actually raised
+            print(f"SQL++ exception happened ({type(_err).__name__}): {_err}")
+
+        return None
+
+    @staticmethod
+    def _has_operator(string: str):
+        """determine if a column/key has an operator"""
+        return len(re.findall(r"(\s|<|>|!|=|is null|is not null)", string)) > 0
+
+    @staticmethod
+    def _clean_key(string):
+        """clean a column/key from any non-word chars"""
+        new_key = re.sub(r"\W", "", string)
+        return escape_str(new_key)
+
+    @staticmethod
+    def _enclose_reserved_word(word):
+        """enclose reserved words"""
+        reserved = (
+            "_INDEX_CONDITION",
+            "_INDEX_KEY",
+            "ADVISE",
+            "ALL",
+            "ALTER",
+            "ANALYZE",
+            "AND",
+            "ANY",
+            "ARRAY",
+            "AS",
+            "ASC",
+            "AT",
+            "BEGIN",
+            "BETWEEN",
+            "BINARY",
+            "BOOLEAN",
+            "BREAK",
+            "BUCKET",
+            "BUILD",
+            "BY",
+            "CACHE",
+            "CALL",
+            "CASE",
+            "CAST",
+            "CLUSTER",
+            "COLLATE",
+            "COLLECTION",
+            "COMMIT",
+            "COMMITTED",
+            "CONNECT",
+            "CONTINUE",
+            "CORRELATED",
+            "COVER",
+            "CREATE",
+            "CURRENT",
+            "CYCLE",
+            "DATABASE",
+            "DATASET",
+            "DATASTORE",
+            "DECLARE",
+            "DECREMENT",
+            "DEFAULT",
+            "DELETE",
+            "DERIVED",
+            "DESC",
+            "DESCRIBE",
+            "DISTINCT",
+            "DO",
+            "DROP",
+            "EACH",
+            "ELEMENT",
+            "ELSE",
+            "END",
+            "ESCAPE",
+            "EVERY",
+            "EXCEPT",
+            "EXCLUDE",
+            "EXECUTE",
+            "EXISTS",
+            "EXPLAIN",
+            "FALSE",
+            "FETCH",
+            "FILTER",
+            "FIRST",
+            "FLATTEN",
+            "FLATTEN_KEYS",
+            "FLUSH",
+            "FOLLOWING",
+            "FOR",
+            "FORCE",
+            "FROM",
+            "FTS",
+            "FUNCTION",
+            "GOLANG",
+            "GRANT",
+            "GROUP",
+            "GROUPS",
+            "GSI",
+            "HASH",
+            "HAVING",
+            "IF",
+            "IGNORE",
+            "ILIKE",
+            "IN",
+            "INCLUDE",
+            "INCREMENT",
+            "INDEX",
+            "INFER",
+            "INLINE",
+            "INNER",
+            "INSERT",
+            "INTERSECT",
+            "INTO",
+            "IS",
+            "ISOLATION",
+            "JAVASCRIPT",
+            "JOIN",
+            "KEY",
+            "KEYS",
+            "KEYSPACE",
+            "KNOWN",
+            "LANGUAGE",
+            "LAST",
+            "LATERAL",
+            "LEFT",
+            "LET",
+            "LETTING",
+            "LEVEL",
+            "LIKE",
+            "LIMIT",
+            "LSM",
+            "MAP",
+            "MAPPING",
+            "MATCHED",
+            "MATERIALIZED",
+            "MAXVALUE",
+            "MERGE",
+            "MINVALUE",
+            "MISSING",
+            "NAMESPACE",
+            "NEST",
+            "NEXT",
+            "NEXTVAL",
+            "NL",
+            "NO",
+            "NOT",
+            "NTH_VALUE",
+            "NULL",
+            "NULLS",
+            "NUMBER",
+            "OBJECT",
+            "OFFSET",
+            "ON",
+            "OPTION",
+            "OPTIONS",
+            "OR",
+            "ORDER",
+            "OTHERS",
+            "OUTER",
+            "OVER",
+            "PARSE",
+            "PARTITION",
+            "PASSWORD",
+            "PATH",
+            "POOL",
+            "PRECEDING",
+            "PREPARE",
+            "PREV",
+            "PREVIOUS",
+            "PREVVAL",
+            "PRIMARY",
+            "PRIVATE",
+            "PRIVILEGE",
+            "PROBE",
+            "PROCEDURE",
+            "PUBLIC",
+            "RANGE",
+            "RAW",
+            "READ",
+            "REALM",
+            "RECURSIVE",
+            "REDUCE",
+            "RENAME",
+            "REPLACE",
+            "RESPECT",
+            "RESTART",
+            "RESTRICT",
+            "RETURN",
+            "RETURNING",
+            "REVOKE",
+            "RIGHT",
+            "ROLE",
+            "ROLLBACK",
+            "ROW",
+            "ROWS",
+            "SATISFIES",
+            "SAVEPOINT",
+            "SCHEMA",
+            "SCOPE",
+            "SELECT",
+            "SELF",
+            "SEQUENCE",
+            "SET",
+            "SHOW",
+            "SOME",
+            "START",
+            "STATISTICS",
+            "STRING",
+            "SYSTEM",
+            "THEN",
+            "TIES",
+            "TO",
+            "TRAN",
+            "TRANSACTION",
+            "TRIGGER",
+            "TRUE",
+            "TRUNCATE",
+            "UNBOUNDED",
+            "UNDER",
+            "UNION",
+            "UNIQUE",
+            "UNKNOWN",
+            "UNNEST",
+            "UNSET",
+            "UPDATE",
+            "UPSERT",
+            "USE",
+            "USER",
+            "USERS",
+            "USING",
+            "VALIDATE",
+            "VALUE",
+            "VALUED",
+            "VALUES",
+            "VECTOR",
+            "VIA",
+            "VIEW",
+            "WHEN",
+            "WHERE",
+            "WHILE",
+            "WINDOW",
+            "WITH",
+            "WITHIN",
+            "WORK",
+            "XOR",
+        )
+
+        if word.upper() in reserved:
+            word = f"`{word}`"
+
+        return word

--- a/couchbase_helper/options.py
+++ b/couchbase_helper/options.py
@@ -1,0 +1,100 @@
+from datetime import timedelta
+from typing import Any, Dict, Optional, Union
+
+from couchbase.options import (
+    InsertMultiOptions,
+    InsertOptions,
+    GetMultiOptions,
+    GetOptions,
+    QueryOptions,
+    RemoveMultiOptions,
+    RemoveOptions,
+    UpsertMultiOptions,
+    UpsertOptions,
+    ViewOptions,
+)
+
+from .session import Session
+from .timeout import Timeout
+
+_TIMEOUT = Timeout()
+
+
+def build_opts(
+    type_: str,
+    *,
+    opts: Optional[Dict[str, Any]] = None,
+    expiry: Optional[Union[int, timedelta]] = None,
+    session: Optional[Session] = None,
+) -> Union[
+    InsertOptions,
+    InsertMultiOptions,
+    UpsertOptions,
+    UpsertMultiOptions,
+    GetOptions,
+    GetMultiOptions,
+    QueryOptions,
+    RemoveOptions,
+    RemoveMultiOptions,
+    ViewOptions,
+]:
+    """Generates operation options for specified operation type.
+
+    Args:
+        type_ (str):
+            The type of operation to return options for.
+        opts (Dict[str, Any]):
+            Optional options to use for initiating the operation options instance.
+        expiry (int | timedelta | None):
+            Optional general document expiry to use for the operations.
+        session (couchbase_helper.Session):
+            Optional session to fetch timeout settings from
+
+    Returns:
+        Dict[str, Any]
+    """
+    if opts is None:
+        opts = {}
+
+    if session is not None:
+        timeout = session.timeout
+    else:
+        timeout = _TIMEOUT
+
+    default_timeout = timedelta(seconds=timeout.kv)
+    if type_ == "insert":
+        base_options = InsertOptions
+    elif type_ == "insert_multi":
+        base_options = InsertMultiOptions
+    elif type_ == "upsert":
+        base_options = UpsertOptions
+    elif type_ == "upsert_multi":
+        base_options = UpsertMultiOptions
+    elif type_ == "get":
+        base_options = GetOptions
+    elif type_ == "get_multi":
+        base_options = GetMultiOptions
+    elif type_ == "query":
+        base_options = QueryOptions
+        default_timeout = timedelta(seconds=timeout.query)
+    elif type_ == "remove":
+        base_options = RemoveOptions
+    elif type_ == "remove_multi":
+        base_options = RemoveMultiOptions
+    elif type_ == "view":
+        base_options = ViewOptions
+    else:
+        raise AttributeError(f"invalid attribute value {type_}")
+
+    if "timeout" not in opts:
+        opts["timeout"] = default_timeout
+
+    ret = base_options(**opts)
+
+    if ret is None:
+        ret = {}
+
+    if expiry is not None and isinstance(expiry, int):
+        ret["expiry"] = timedelta(seconds=expiry)
+
+    return ret

--- a/couchbase_helper/session.py
+++ b/couchbase_helper/session.py
@@ -130,8 +130,7 @@ class Session(SessionProt):
         self.logger.debug("- Connecting to cluster: %s", self.connection_string)
 
         if self._cluster is None:
-            self._cluster = Cluster
-        self._cluster.connect(self.connection_string, self.options)
+            self._cluster = Cluster(self.connection_string, self.options)
 
         if self._bucket_name is not None:
             self.bucket = self._bucket_name

--- a/tests/couchbase_session.py
+++ b/tests/couchbase_session.py
@@ -1,7 +1,7 @@
 from couchbase.auth import PasswordAuthenticator
 from couchbase.options import ClusterOptions
-from couchbase_helper import CouchbaseHelper
-from couchbase_helper import Session
+from couchbase_helper import CouchbaseHelper, Session
+from couchbase_helper.n1ql import N1ql
 from fake_couchbase.cluster import Cluster as FakeCluster
 
 username = "test"
@@ -11,12 +11,21 @@ session = Session(
     hostname="localhost", username=username, password=password, bucket="test"
 )
 session.cluster = FakeCluster(session.connection_string, options)
-_INSTANCE = None
+_CB_INSTANCE = None
+_N1QL_INSTANCE = None
 
 
-def instance():
-    global _INSTANCE
-    if _INSTANCE is None:
-        _INSTANCE = CouchbaseHelper(session=session)
+def cb_instance() -> CouchbaseHelper:
+    global _CB_INSTANCE
+    if _CB_INSTANCE is None:
+        _CB_INSTANCE = CouchbaseHelper(session=session)
 
-    return _INSTANCE
+    return _CB_INSTANCE
+
+
+def n1ql_instance() -> N1ql:
+    global _N1QL_INSTANCE
+    if _N1QL_INSTANCE is None:
+        _N1QL_INSTANCE = N1ql(session=session)
+
+    return _N1QL_INSTANCE

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -6,7 +6,7 @@ import pytest
 from couchbase_helper.protocols import SessionProt
 from couchbase_helper import Timeout
 
-from .couchbase_session import instance, session
+from .couchbase_session import cb_instance, session
 from .helpers import get_item, get_items
 
 
@@ -49,41 +49,41 @@ def test_connect():
 ##################################################
 def test_insert():
     key, document = get_item()
-    assert instance().insert(key, document)
+    assert cb_instance().insert(key, document)
 
 
 def test_insert_duplicate():
     key, document = get_item()
-    assert not instance().insert(key, document)
+    assert not cb_instance().insert(key, document)
 
 
 def test_insert_multi():
     documents_raw = get_items(100)
     documents = {key: document for key, document in documents_raw}
-    assert instance().insert_multi(documents)
+    assert cb_instance().insert_multi(documents)
 
 
 def test_upsert_existing():
     key, document = get_item()
-    assert instance().upsert(key, document)
+    assert cb_instance().upsert(key, document)
 
 
 def test_upsert():
     key, document = get_item("second")
-    assert instance().upsert(key, document)
+    assert cb_instance().upsert(key, document)
 
 
 def test_upsert_multi():
     documents_raw = get_items(100)
     documents = {key: document for key, document in documents_raw}
-    assert instance().upsert_multi(documents)
+    assert cb_instance().upsert_multi(documents)
 
 
 @pytest.mark.order(after="test_insert")
 def test_update():
     key, document = get_item()
     document["update"] = True
-    assert instance().upsert(key, document)
+    assert cb_instance().upsert(key, document)
 
 
 ##################################################
@@ -91,28 +91,28 @@ def test_update():
 ##################################################
 def test_get():
     key, document = get_item("get_test")
-    instance().insert(key, document)
-    document_fetched = instance().get(key)
+    cb_instance().insert(key, document)
+    document_fetched = cb_instance().get(key)
 
     assert json.dumps(document) == json.dumps(document_fetched)
-    assert instance().remove(key)
+    assert cb_instance().remove(key)
 
 
 def test_get_not_found():
     key, _ = get_item("get_not_found_test")
-    assert not instance().get(key)
+    assert not cb_instance().get(key)
 
 
 def test_get_multi():
     documents_raw = get_items(100, "get_multi_test")
     documents = {key: document for key, document in documents_raw}
-    instance().insert_multi(documents)
+    cb_instance().insert_multi(documents)
 
     keys = [key for key, _ in documents_raw]
-    documents_fetched = instance().get_multi(keys, raw=True)
+    documents_fetched = cb_instance().get_multi(keys, raw=True)
     assert len(documents) == len(documents_fetched)
     assert all(doc.key in keys for doc in documents_fetched)
-    assert instance().remove_multi(keys)
+    assert cb_instance().remove_multi(keys)
 
 
 ##################################################
@@ -121,28 +121,28 @@ def test_get_multi():
 @pytest.mark.order(after="test_insert")
 def test_remove():
     key, document = get_item()
-    assert instance().remove(key, document)
+    assert cb_instance().remove(key, document)
 
 
 @pytest.mark.order(after="test_upsert")
 def test_remove_second():
     key, document = get_item("second")
-    assert instance().remove(key, document)
+    assert cb_instance().remove(key, document)
 
 
 @pytest.mark.order(after="test_remove")
 def test_remove_not_found():
     key, document = get_item()
-    assert not instance().remove(key, document)
+    assert not cb_instance().remove(key, document)
 
 
 @pytest.mark.order(after="test_insert_multi")
 def test_remove_multi():
     keys = [key for key, _ in get_items(100)]
-    assert instance().remove_multi(keys)
+    assert cb_instance().remove_multi(keys)
 
 
 @pytest.mark.order(after="test_remove_multi")
 def test_remove_multi_not_found():
     keys = [key for key, _ in get_items(100)]
-    assert not instance().remove_multi(keys)
+    assert not cb_instance().remove_multi(keys)

--- a/tests/test_n1ql.py
+++ b/tests/test_n1ql.py
@@ -1,0 +1,130 @@
+from couchbase_helper.n1ql import N1ql
+
+from .couchbase_session import n1ql_instance
+
+
+##################################################
+# Test instance                                  #
+##################################################
+def test_instance():
+    assert isinstance(n1ql_instance(), N1ql)
+
+
+##################################################
+# Test select                                    #
+##################################################
+def test_select_default():
+    assert n1ql_instance()._columns == ["*"]
+
+
+def test_select_custom_string():
+    n1ql_instance().select("kings,queens")
+    assert n1ql_instance()._columns == ["kings", "queens"]
+
+
+def test_select_custom_list():
+    n1ql_instance().select(["horses", "donkeys"])
+    assert n1ql_instance()._columns == ["horses", "donkeys"]
+
+
+##################################################
+# Test distinct                                  #
+##################################################
+def test_distinct():
+    n1ql_instance().distinct()
+    assert n1ql_instance()._distinct
+
+
+def test_not_distinct():
+    n1ql_instance().distinct(False)
+    assert not n1ql_instance()._distinct
+
+
+##################################################
+# Test from_                                     #
+##################################################
+def test_from_bucket():
+    bucket_name = "bucketname"
+    n1ql_instance().from_(bucket_name)
+    assert n1ql_instance().session.bucket.name == bucket_name
+    n1ql_instance()._reset()
+
+
+def test_from_bucket_scope():
+    bucket_name = "bucketname2"
+    scope_name = "scope2"
+    n1ql_instance().from_(bucket_name, scope_name)
+    assert n1ql_instance().session.bucket.name == bucket_name
+    assert n1ql_instance().session.scope.name == scope_name
+    n1ql_instance()._reset()
+
+
+def test_from_bucket_scope_collection():
+    bucket_name = "bucketname3"
+    scope_name = "scope3"
+    collection_name = "collection3"
+    n1ql_instance().from_(bucket_name, scope_name, collection_name)
+    assert n1ql_instance().session.bucket.name == bucket_name
+    assert n1ql_instance().session.scope.name == scope_name
+    assert n1ql_instance().session.collection.name == collection_name
+
+
+##################################################
+# Test where                                     #
+##################################################
+def test_where():
+    n1ql_instance().where("type=", "random")
+    assert n1ql_instance()._conditions == [("AND", "type =", "random")]
+
+
+def test_where_or():
+    n1ql_instance().or_where("type=", "not-random")
+    assert n1ql_instance()._conditions == [
+        ("AND", "type =", "random"),
+        ("OR", "type =", "not-random"),
+    ]
+
+
+##################################################
+# Test limit                                     #
+##################################################
+def test_limit():
+    n1ql_instance().limit("11")
+    assert n1ql_instance()._limit == 11
+    n1ql_instance().limit(10)
+    assert n1ql_instance()._limit == 10
+    n1ql_instance().limit("invalid-string")
+    assert n1ql_instance()._limit == 10
+
+
+##################################################
+# Test offset/skip                               #
+##################################################
+def test_offset():
+    n1ql_instance().offset(3)
+    assert n1ql_instance()._offset == 3
+    n1ql_instance().offset("4")
+    assert n1ql_instance()._offset == 4
+    n1ql_instance().offset("invalid-string")
+    assert n1ql_instance()._offset == 4
+
+
+##################################################
+# Test rows                                      #
+##################################################
+def test_rows():
+    assert n1ql_instance().rows() is None
+
+
+##################################################
+# Test reset                                     #
+##################################################
+def test_reset():
+    assert n1ql_instance()._columns == ["*"]
+    assert not n1ql_instance()._distinct
+    assert n1ql_instance().session.bucket.name == "test"
+    assert n1ql_instance().session.scope.name == "_default"
+    assert n1ql_instance().session.collection.name == "_default"
+    assert n1ql_instance()._conditions == []
+    assert n1ql_instance()._limit is None
+    assert n1ql_instance()._offset is None


### PR DESCRIPTION
### What's added
- class `couchbase_helper.n1ql.N1ql()`
  - Build SQL++/N1QL queries logically by chaining the classes' methods.
  - Class will automatically create prepared statements, which should increase cachability of the queries on the Couchbase cluster.
  - Class currently only supports `SELECT` statements.
  - Class currently handles `WHERE` expressions including `AND` and `OR`, intention is to support more along the way .. but this should serve as a good foundation for v0.1.0.

Also retro-fitted fix made in 189f828 just so it's not reverted by the release of v0.1.0.