### PR TITLE
fix:fixed missing enclosing of expressions with '.' in them

### DIFF
--- a/couchbase_helper/n1ql.py
+++ b/couchbase_helper/n1ql.py
@@ -228,7 +228,7 @@ class N1ql:
         ):
             from_ += f".{self._enclose_reserved_word(self.session.scope.name)}.{self._enclose_reserved_word(self.session.collection.name)}"
 
-        ident = from_[0:1]
+        ident = self.session.bucket.name[0:1]
         prefix = f"{ident}."
 
         # generate columns for selection
@@ -560,6 +560,9 @@ class N1ql:
         )
 
         if word.upper() in reserved:
+            word = f"`{word}`"
+
+        if "." in word:
             word = f"`{word}`"
 
         return word


### PR DESCRIPTION
In cases where SQL++ queries are made towards bucket names containing '.' (period) they would fail since it's assumed that the period symbolizes using `{bucket}[.{scope}[.{collection}]]` hence one might end up getting errors.