### PR TITLE
feat:use session logger

### DIFF
--- a/couchbase_helper/helper.py
+++ b/couchbase_helper/helper.py
@@ -23,17 +23,20 @@ class CouchbaseHelper:
         session (implements :class:`couchbase_helper.protocols.SessionProt`):
             The cluster connection session
         logger (:class:`logging.logger`):
+            DEPRECATED SINCE v0.1.3, WILL USE SESSION LOGGER INSTEAD
             The logging instance to use for log message. Defaults to the root logger.
     """
 
-    def __init__(
-        self,
-        session: SessionProt,
-        logger: Optional[logging.Logger] = None,
-    ):
-        if logger is None:
-            logger = logging.getLogger()
-        self.logger = logger
+    def __init__(self, session: SessionProt, logger: Optional[logging.Logger] = None):
+        if session.logger is not None:
+            self.logger = session.logger
+        else:
+            self.logger = logging.getLogger()
+
+        if logger is not None:
+            self.logger.warning(
+                "usage of parameter 'logger' in CouchbaseHelper class deprecated since 0.1.3 and will be removed in a future version"
+            )
 
         self.session = session
 

--- a/couchbase_helper/n1ql.py
+++ b/couchbase_helper/n1ql.py
@@ -20,6 +20,7 @@ class N1ql:
         session (implements :class:`~couchbase_helper.protocols.SessionProt`)
             The cluster connection session
         logger (:class:`logging.logger`):
+            DEPRECATED SINCE v0.1.3, WILL USE SESSION LOGGER INSTEAD
             The logging instance to use for log message. Defaults to the root logger.
 
     Usage:
@@ -44,9 +45,15 @@ class N1ql:
     """
 
     def __init__(self, session: Session, logger: Optional[logging.Logger] = None):
-        if logger is None:
-            logger = logging.getLogger()
-        self.logger = logger
+        if session.logger is not None:
+            self.logger = session.logger
+        else:
+            self.logger = logging.getLogger()
+
+        if logger is not None:
+            self.logger.warning(
+                "usage of parameter 'logger' in CouchbaseHelper class deprecated since 0.1.3 and will be removed in a future version"
+            )
 
         self.session = session
 

--- a/couchbase_helper/protocols.py
+++ b/couchbase_helper/protocols.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Protocol
 
 from couchbase.bucket import Collection, Scope
@@ -7,6 +8,8 @@ from .timeout import Timeout
 
 
 class SessionProt(Protocol):
+    logger: logging.Logger
+
     def connect(self): ...
 
     def disconnect(self): ...


### PR DESCRIPTION
- Instead of passing a logger to both the Session class as well as either the CouchbaseHelper or N1ql classes, the latter two will now just use the Session's defined logger.