### PR TITLE
rel:v0.1.3

### DIFF
--- a/couchbase_helper/__init__.py
+++ b/couchbase_helper/__init__.py
@@ -4,4 +4,4 @@ from .timeout import Timeout
 
 __all__ = ["CouchbaseHelper", "Session", "Timeout"]
 __author__ = "Thomas 'sitzz' Vang <sitzzdk@gmail.com>"
-__version__ = "0.1.2"
+__version__ = "0.1.3"

--- a/couchbase_helper/helper.py
+++ b/couchbase_helper/helper.py
@@ -23,17 +23,20 @@ class CouchbaseHelper:
         session (implements :class:`couchbase_helper.protocols.SessionProt`):
             The cluster connection session
         logger (:class:`logging.logger`):
+            DEPRECATED SINCE v0.1.3, WILL USE SESSION LOGGER INSTEAD
             The logging instance to use for log message. Defaults to the root logger.
     """
 
-    def __init__(
-        self,
-        session: SessionProt,
-        logger: Optional[logging.Logger] = None,
-    ):
-        if logger is None:
-            logger = logging.getLogger()
-        self.logger = logger
+    def __init__(self, session: SessionProt, logger: Optional[logging.Logger] = None):
+        if session.logger is not None:
+            self.logger = session.logger
+        else:
+            self.logger = logging.getLogger()
+
+        if logger is not None:
+            self.logger.warning(
+                "usage of parameter 'logger' in CouchbaseHelper class deprecated since 0.1.3 and will be removed in a future version"
+            )
 
         self.session = session
 

--- a/couchbase_helper/helper.py
+++ b/couchbase_helper/helper.py
@@ -23,20 +23,20 @@ class CouchbaseHelper:
         session (implements :class:`couchbase_helper.protocols.SessionProt`):
             The cluster connection session
         logger (:class:`logging.logger`):
-            DEPRECATED SINCE v0.1.3, WILL USE SESSION LOGGER INSTEAD
+            DEPRECATED SINCE v0.1.3, SHOULD USE SESSION LOGGER INSTEAD
             The logging instance to use for log message. Defaults to the root logger.
     """
 
     def __init__(self, session: SessionProt, logger: Optional[logging.Logger] = None):
-        if session.logger is not None:
-            self.logger = session.logger
-        else:
-            self.logger = logging.getLogger()
-
         if logger is not None:
+            self.logger = logger
             self.logger.warning(
                 "usage of parameter 'logger' in CouchbaseHelper class deprecated since 0.1.3 and will be removed in a future version"
             )
+        elif session.logger is not None:
+            self.logger = session.logger
+        else:
+            self.logger = logging.getLogger()
 
         self.session = session
 

--- a/couchbase_helper/n1ql.py
+++ b/couchbase_helper/n1ql.py
@@ -20,7 +20,7 @@ class N1ql:
         session (implements :class:`~couchbase_helper.protocols.SessionProt`)
             The cluster connection session
         logger (:class:`logging.logger`):
-            DEPRECATED SINCE v0.1.3, WILL USE SESSION LOGGER INSTEAD
+            DEPRECATED SINCE v0.1.3, SHOULD USE SESSION LOGGER INSTEAD
             The logging instance to use for log message. Defaults to the root logger.
 
     Usage:
@@ -45,15 +45,15 @@ class N1ql:
     """
 
     def __init__(self, session: Session, logger: Optional[logging.Logger] = None):
-        if session.logger is not None:
+        if logger is not None:
+            self.logger = logger
+            self.logger.warning(
+                "usage of parameter 'logger' in N1ql class deprecated since 0.1.3 and will be removed in a future version"
+            )
+        elif session.logger is not None:
             self.logger = session.logger
         else:
             self.logger = logging.getLogger()
-
-        if logger is not None:
-            self.logger.warning(
-                "usage of parameter 'logger' in CouchbaseHelper class deprecated since 0.1.3 and will be removed in a future version"
-            )
 
         self.session = session
 

--- a/couchbase_helper/n1ql.py
+++ b/couchbase_helper/n1ql.py
@@ -20,6 +20,7 @@ class N1ql:
         session (implements :class:`~couchbase_helper.protocols.SessionProt`)
             The cluster connection session
         logger (:class:`logging.logger`):
+            DEPRECATED SINCE v0.1.3, WILL USE SESSION LOGGER INSTEAD
             The logging instance to use for log message. Defaults to the root logger.
 
     Usage:
@@ -44,9 +45,15 @@ class N1ql:
     """
 
     def __init__(self, session: Session, logger: Optional[logging.Logger] = None):
-        if logger is None:
-            logger = logging.getLogger()
-        self.logger = logger
+        if session.logger is not None:
+            self.logger = session.logger
+        else:
+            self.logger = logging.getLogger()
+
+        if logger is not None:
+            self.logger.warning(
+                "usage of parameter 'logger' in CouchbaseHelper class deprecated since 0.1.3 and will be removed in a future version"
+            )
 
         self.session = session
 

--- a/couchbase_helper/protocols.py
+++ b/couchbase_helper/protocols.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Protocol
 
 from couchbase.bucket import Collection, Scope
@@ -7,6 +8,8 @@ from .timeout import Timeout
 
 
 class SessionProt(Protocol):
+    logger: logging.Logger
+
     def connect(self): ...
 
     def disconnect(self): ...

--- a/couchbase_helper/retry.py
+++ b/couchbase_helper/retry.py
@@ -17,7 +17,7 @@ def retry(
     attempts: int = 3,
     delay: float = 0.1,
     policy: RetryPolicy = RetryPolicy.FLAT,
-    exceptions: Optional[Tuple[Exception]] = None,
+    exceptions: Optional[Tuple[type[Exception]]] = None,
 ) -> Callable:
     def handler(func):
         @wraps(func)
@@ -41,6 +41,8 @@ def retry(
                         backoff = delay * (randint(17, 233) / 100)
 
                     sleep(backoff)
+
+            return None
 
         return wrapper
 


### PR DESCRIPTION
# Release PR for version 0.1.3

This is the PR which includes all changes to be included in the release of version 0.1.3.

## Changes
#40 - feat:use session logger
> Instead of passing a logger to both the Session class as well as either the CouchbaseHelper or N1ql classes, the latter two will now just use the Session's defined logger.


#42 - chore:tweaked retry decorator type hint and return
> Tweaked the type hint for the exceptions parameter of the retry decorator as some (Pycharm) editors were complaining about it.
Also added an explicit return.

__WIP - Please update PR description as/is more changes are added__