### PR TITLE
chore:tweaked retry decorator type hint and return

### DIFF
--- a/couchbase_helper/retry.py
+++ b/couchbase_helper/retry.py
@@ -17,7 +17,7 @@ def retry(
     attempts: int = 3,
     delay: float = 0.1,
     policy: RetryPolicy = RetryPolicy.FLAT,
-    exceptions: Optional[Tuple[Exception]] = None,
+    exceptions: Optional[Tuple[type[Exception]]] = None,
 ) -> Callable:
     def handler(func):
         @wraps(func)
@@ -41,6 +41,8 @@ def retry(
                         backoff = delay * (randint(17, 233) / 100)
 
                     sleep(backoff)
+
+            return None
 
         return wrapper
 


### PR DESCRIPTION
Tweaked the type hint for the `exceptions` parameter of the `retry` decorator as some (Pycharm) editors were complaining about it.
Also added an explicit return.